### PR TITLE
AI fix for Coverity defect 8 An object is used after it's moved.

### DIFF
--- a/samples/omp_hot_regions/omp_region_collector.h
+++ b/samples/omp_hot_regions/omp_region_collector.h
@@ -79,7 +79,8 @@ class OmpRegionCollector {
   }
 
   const RegionMap& GetRegionMap() const {
-    return region_map_;
+  std::lock_guard<std::mutex> lock(lock_);
+  return region_map_;
   }
 
   static void PrintRegionTable(const RegionMap& region_map) {


### PR DESCRIPTION
LLM fix suggestion: 
 To fix the data race condition, you should acquire the lock "OmpRegionCollector.lock_" before accessing "this->region_map_". You can do this by adding a lock_guard in the GetRegionMap function. Here is the modified code:

```cpp
const RegionMap& OmpRegionCollector::GetRegionMap() const {
  std::lock_guard<std::mutex> lock(lock_);
  return region_map_;
}
```

This ensures that the lock is held while accessing "region_map_", preventing the data race condition.