### PR TITLE
AI fix for Coverity defect #1: COPY_INSTEAD_OF_MOVE

### DIFF
--- a/tools/oneprof/profiler.h
+++ b/tools/oneprof/profiler.h
@@ -315,8 +315,8 @@ class Profiler {
         correlator_.GetTimestamp(),
         options_.GetMetricGroup(),
         device_props_list_,
-        kernel_name_list,
-        kernel_interval_list};
+        std::move(kernel_name_list),
+        std::move(kernel_interval_list)};
 
     storage->Dump(&data);
 


### PR DESCRIPTION
**Coverity issue**:
Creating a copy of a variable that is no longer used instead of using std::move().
**LLM fix suggestion**:
The fix is to use `std::move` when creating the `ResultData` object, like this:
```cpp
ResultData data{
    utils::GetPid(),
    device_id_,
    correlator_.GetTimestamp(),
    options_.GetMetricGroup(),
    device_props_list_,
    std::move(kernel_name_list),
    std::move(kernel_interval_list)};
```
This will move the contents of `kernel_interval_list` and `kernel_name_list` into the `ResultData` object, instead of creating a copy.