### PR TITLE
AI fix for Coverity defect 1

### DIFF
--- a/tools/oneprof/profiler.h
+++ b/tools/oneprof/profiler.h
@@ -315,8 +315,8 @@ class Profiler {
         correlator_.GetTimestamp(),
         options_.GetMetricGroup(),
         device_props_list_,
-        kernel_name_list,
-        kernel_interval_list};
+        std::move(kernel_name_list),
+        std::move(kernel_interval_list)};
 
     storage->Dump(&data);
 


### PR DESCRIPTION
Patch suggested by an automated Coverity-with-AI tool for the following issue: Creating a copy of a variable that is no longer used instead of using std::move().