### PR TITLE
AI fix for Coverity defect 2: COPY_INSTEAD_OF_MOVE

### DIFF
--- a/tools/oneprof/profiler.h
+++ b/tools/oneprof/profiler.h
@@ -315,7 +315,7 @@ class Profiler {
         correlator_.GetTimestamp(),
         options_.GetMetricGroup(),
         device_props_list_,
-        kernel_name_list,
+        std::move(kernel_name_list),
         kernel_interval_list};
 
     storage->Dump(&data);


### PR DESCRIPTION
A fix suggested by an automated Coverity-with-AI tool for the following issue: 
 Creating a copy of a variable that is no longer used instead of using std::move().

The fix is to use `std::move` when creating the `ResultData` object, like this:
```cpp
ResultData data{
    utils::GetPid(),
    device_id_,
    correlator_.GetTimestamp(),
    options_.GetMetricGroup(),
    device_props_list_,
    std::move(kernel_name_list),
    kernel_interval_list};
```
This will move the contents of `kernel_name_list` into the `ResultData` object instead of copying it, which is more efficient and fixes the issue.