### PR TITLE
AI fix for Coverity defect 8: Data race condition

### DIFF
--- a/samples/omp_hot_regions/omp_region_collector.h
+++ b/samples/omp_hot_regions/omp_region_collector.h
@@ -79,7 +79,8 @@ class OmpRegionCollector {
   }
 
   const RegionMap& GetRegionMap() const {
-    return region_map_;
+  std::lock_guard<std::mutex> lock(lock_);
+  return region_map_;
   }
 
   static void PrintRegionTable(const RegionMap& region_map) {


### PR DESCRIPTION
A fix suggested by an automated Coverity-with-AI tool for the following issue: 
 Thread shared data is accessed without holding an appropriate lock, possibly causing a race condition

To fix the data race condition, we need to ensure that the lock "OmpRegionCollector.lock_" is held when accessing "this->region_map_". We can do this by adding a lock guard to the GetRegionMap function. Here's the modified code:

```cpp
const RegionMap& OmpRegionCollector::GetRegionMap() const {
  std::lock_guard<std::mutex> lock(lock_);
  return region_map_;
}
```

This will ensure that the lock is held when accessing "region_map_", preventing the data race condition.